### PR TITLE
Removed node-canvas install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,3 @@ An angular directive for lindell's JsBarcode
 # Usage
 
 Take a look at the example/index.html
-
-
-# Dev
-
-You will need to setup the canvas package manually: https://www.npmjs.com/package/canvas


### PR DESCRIPTION
The `node-canvas` was previously set as an dependency for JsBarcode. Just removed that since people wanting to use JsBarcode for node has to install that anyway in their own project. This means that it is no longer required to do any manual installation and can be done directly through npm :smile: 